### PR TITLE
Rename conda role

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,4 +14,4 @@ warn_list:
 
 exclude_paths:
   - .github/
-  - molecule/default/client-binary-existance.yml
+  - molecule/default/client-binary-existance.yml # ansible-lint thinks it's a playbook so gives an error, but it's tasks for include_task. decided to exclude it

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,3 +14,4 @@ warn_list:
 
 exclude_paths:
   - .github/
+  - molecule/default/client-binary-existance.yml

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -24,6 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Clean micromamba cache
+        run: |
+          rm -rf ~/micromamba/pkgs/*
+          rm -rf ~/micromamba/pkgs/cache/*
+
       - uses: mamba-org/setup-micromamba@feb7656f829886af1ab11cf61126b048557b2e19
         with:
           micromamba-version: '2.0.5-0'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ udp 21116
 Role Variables
 --------------
 
-``` rustdesk_server_version ``` — contains rustdesk-server version to be installed
+``` rustdesk_server_version ``` — contains rustdesk-server version to be installed  
 ``` rustdesk_client_version ``` — contains rustdesk-client version for executable to be configured
 
 Dependencies

--- a/conda.dev.yml
+++ b/conda.dev.yml
@@ -1,5 +1,5 @@
 ---
-name: ansible-role-template
+name: ansible-rustdesk
 channels:
   - conda-forge
 dependencies:

--- a/conda.prod.yml
+++ b/conda.prod.yml
@@ -1,5 +1,5 @@
 ---
-name: ansible-role-template
+name: ansible-rustdesk
 channels:
   - conda-forge
 dependencies:

--- a/molecule/default/client-binary-existance.yml
+++ b/molecule/default/client-binary-existance.yml
@@ -1,22 +1,28 @@
 ---
 - name: "Get public IP"
+  register: public_ip
+  changed_when: false
   ansible.builtin.uri:
     url: https://ifconfig.me
     return_content: true
-  register: public_ip
-  changed_when: false
+    headers:
+      Accept: text/plain
+      User-Agent: curl/7.68.0
+
 
 - name: "Get public key"
-  ansible.builtin.command: "cat /opt/rustdesk-server/lib/id_ed25519.pub"
   register: public_key
   changed_when: false
-
-- name: "Check client rustdesk binary existence"
+  ansible.builtin.command: "cat /opt/rustdesk-server/lib/id_ed25519.pub"
+    
+- name: "Get client rustdesk binary information"
+  changed_when: false
+  register: rustdesk_bin
   ansible.builtin.stat:
     path: "/opt/rustdesk-server/lib/rustdesk-host={{ public_ip.content }},key={{ public_key.stdout }}.exe"
-  register: rustdesk_bin
 
-- name: "Check if binary exists"
+- name: "Check if client binary exists"
+  changed_when: false
   ansible.builtin.assert:
     that: "rustdesk_bin.stat.exists"
     success_msg: "Rustdesk binary exists and named correctly"

--- a/molecule/default/client-binary-existance.yml
+++ b/molecule/default/client-binary-existance.yml
@@ -1,0 +1,21 @@
+---
+- name: "Get public IP"
+  ansible.builtin.command: "curl -s ifconfig.me"
+  register: public_ip
+  changed_when: false
+
+- name: "Get public key"
+  ansible.builtin.command: "cat /opt/rustdesk-server/lib/id_ed25519.pub"
+  register: public_key
+  changed_when: false
+
+- name: "Check client rustdesk binary existance"
+  ansible.builtin.stat:
+    path: "/opt/rustdesk-server/lib/rustdesk-host={{ public_ip.stdout }},key={{ public_key.stdout }}.exe"
+  register: rustdesk_bin
+
+- name: "Check if binary exists"
+  ansible.builtin.assert:
+    that: rustdesk_bin.stat.exists
+    success_msg: "Rustdesk binary exists and named correctly"
+    fail_msg: "Rustdesk binary not found"

--- a/molecule/default/client-binary-existance.yml
+++ b/molecule/default/client-binary-existance.yml
@@ -1,6 +1,8 @@
 ---
 - name: "Get public IP"
-  ansible.builtin.command: "curl -s ifconfig.me"
+  ansible.builtin.uri:
+    url: https://ifconfig.me
+    return_content: true
   register: public_ip
   changed_when: false
 
@@ -9,13 +11,13 @@
   register: public_key
   changed_when: false
 
-- name: "Check client rustdesk binary existance"
+- name: "Check client rustdesk binary existence"
   ansible.builtin.stat:
-    path: "/opt/rustdesk-server/lib/rustdesk-host={{ public_ip.stdout }},key={{ public_key.stdout }}.exe"
+    path: "/opt/rustdesk-server/lib/rustdesk-host={{ public_ip.content }},key={{ public_key.stdout }}.exe"
   register: rustdesk_bin
 
 - name: "Check if binary exists"
   ansible.builtin.assert:
-    that: rustdesk_bin.stat.exists
+    that: "rustdesk_bin.stat.exists"
     success_msg: "Rustdesk binary exists and named correctly"
     fail_msg: "Rustdesk binary not found"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Verify
   hosts: all
   gather_facts: false

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,6 +3,8 @@
   hosts: all
   gather_facts: false
   any_errors_fatal: true
+  vars_files:
+    - ../../defaults/main.yml
 
   tasks:
     - name: "Gather service facts"
@@ -19,3 +21,6 @@
         that: "ansible_facts.services['rustdesk-hbbs.service'].state == 'running'"
         success_msg: "rustdesk-hbbs is running"
         fail_msg: "rustdesk-hbbs is NOT running"
+
+    - name: "Check client binary existance"
+      ansible.builtin.include_tasks: client-binary-existance.yml

--- a/tasks/check-rustdesk-version.yml
+++ b/tasks/check-rustdesk-version.yml
@@ -8,7 +8,7 @@
 
 - name: "Check if the version of hbbr is the expected one"
   ansible.builtin.assert:
-    that: "hbbr_output.stdout == 'hbbr {{ rustdesk_version }}'"
+    that: "hbbr_output.stdout == 'hbbr {{ rustdesk_server_version }}'"
     success_msg: "hbbr is installed and is the correct version"
     fail_msg: "hbbr is either not installed or does not match the target version"
 
@@ -20,6 +20,6 @@
 
 - name: "Check if the version of hbbs is the expected one"
   ansible.builtin.assert:
-    that: "hbbs_output.stdout == 'hbbs {{ rustdesk_version }}'"
+    that: "hbbs_output.stdout == 'hbbs {{ rustdesk_server_version }}'"
     success_msg: "hbbs is installed and is the correct version"
     fail_msg: "hbbs is either not installed or does not match the target version"


### PR DESCRIPTION
the conda role used to be named "ansible-role-template" and i somehow missed it.
renamed to ansible-rustdesk